### PR TITLE
Validate default value if set for Nullable

### DIFF
--- a/valideer/tests/test_validators.py
+++ b/valideer/tests/test_validators.py
@@ -4,7 +4,6 @@ from functools import partial
 import collections
 import json
 import re
-import types
 import unittest
 import valideer as V
 from valideer.compat import long, unicode, xrange, string_types, int_types
@@ -388,6 +387,10 @@ class TestValidator(unittest.TestCase):
                              adapted=[(None, -1), (0, 0)],
                              invalid=[1.1, True, False])
 
+        with self.assertRaises(V.ValidationError):
+            self.parse(V.Nullable("integer", 1.1)).validate(None)
+
+
     def test_nullable_with_default_object_property(self):
         class ObjectNullable(V.Nullable):
             default_object_property = property(lambda self: self.default)
@@ -548,7 +551,7 @@ class TestValidator(unittest.TestCase):
         def f(a):
             return a
 
-        @V.returns(V.Type(types.NoneType))
+        @V.returns(V.Type(type(None)))
         def g(a=True):
             if a:
                 return a

--- a/valideer/validators.py
+++ b/valideer/validators.py
@@ -104,7 +104,10 @@ class Nullable(Validator):
             if isinstance(validator, (Nullable, NonNullable)):
                 validator = validator._validator
             self._validator = validator
+
         self._default = default
+        if self.default is not None:
+            self._validator.validate(self.default)
 
     def validate(self, value, adapt=True):
         if value is None:


### PR DESCRIPTION
Thank you for awesome work!

I think it is really useful, because now I use trick by double validating to get this behaviour, like:
```
    conf = schema.validate(conf)
    conf = schema.validate(conf)
```
Also I fixed tests for Python3 by [`types.NoneType -> type(None)`](http://bugs.python.org/issue19438).