### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,16 +8,16 @@ Valideer
 .. image:: https://coveralls.io/repos/podio/valideer/badge.svg?branch=master
     :target: https://coveralls.io/r/podio/valideer?branch=master
 
-.. image:: https://pypip.in/status/valideer/badge.svg
+.. image:: https://img.shields.io/pypi/status/valideer.svg
     :target: https://pypi.python.org/pypi/valideer/
 
-.. image:: https://pypip.in/version/valideer/badge.svg
+.. image:: https://img.shields.io/pypi/v/valideer.svg
     :target: https://pypi.python.org/pypi/valideer/
 
-.. image:: https://pypip.in/py_versions/valideer/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/valideer.svg
     :target: https://pypi.python.org/pypi/valideer/
 
-.. image:: https://pypip.in/license/valideer/badge.svg
+.. image:: https://img.shields.io/pypi/l/valideer.svg
     :target: https://pypi.python.org/pypi/valideer/
 
 Lightweight data validation and adaptation library for Python.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20valideer))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `valideer`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.