### PR TITLE
Use collections.abc.Sequence

### DIFF
--- a/valideer/validators.py
+++ b/valideer/validators.py
@@ -466,7 +466,7 @@ def _PatternFactory(obj):
 class HomogeneousSequence(Type):
     """A validator that accepts homogeneous, non-fixed size sequences."""
 
-    accept_types = collections.Sequence
+    accept_types = collections.abc.Sequence
     reject_types = string_types
 
     def __init__(self, item_schema=None, min_length=None, max_length=None):


### PR DESCRIPTION
Problem:
`collections.Sequence` has moved to the `collections.abc` in python 3.3 and will be removed in 3.10:

https://docs.python.org/3.9/library/collections.html#:~:text=Deprecated%20since%20version%203.3%2C%20will%20be%20removed%20in%20version%203.10%3A%20Moved%20Collections%20Abstract%20Base%20Classes%20to%20the%20collections.abc%20module.%20For%20backwards%20compatibility%2C%20they%20continue%20to%20be%20visible%20in%20this%20module%20through%20Python%203.9.

Solution
Use `collections.abc.Sequence` instead.