### PR TITLE
Check compatibility with other python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@
 
 language: python
 python:
-  - "3.4"
-  - "3.3"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"      # current default Python on Travis CI
+  - "3.7"
+  - "3.8"
+  - "3.9"
   - "pypy"
 install: pip install coveralls
 script: coverage run --source=valideer setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests in multiple virtualenvs.
+# This configuration file helps to run the test suite on all supported Python versions.
+# To use it, "python -m pip install tox" and  then run "tox" from this directory.
+
+[tox]
+envlist =
+    py27
+    py35
+    py36
+    py37
+    py38
+    py39
+skip_missing_interpreters = true
+minversion = 3.12
+
+[testenv]
+deps = coveralls
+commands =
+    coverage run --source=valideer setup.py test
+
+[testenv:py38]
+basepython = python3
+deps = coveralls
+commands =
+    coverage run --source=valideer setup.py test


### PR DESCRIPTION
Current supported matrix suggests Valideer is only compatible with py27,33. and 34.
Added more versions to `.travis.yml` to check if it passes for newer python versions.